### PR TITLE
Fix of unscreened bremsstrahlung

### DIFF
--- a/examples/Bremsstrahlung/pi
+++ b/examples/Bremsstrahlung/pi
@@ -53,13 +53,9 @@ tools              = rad;
 }
 
 @RadiationModel cone {
-    # !!!!!!!!!!!!!!!!!!!!!!!!!!!
-    # This is the only setting
-    # specific to bremsstrahlung
-    # !!!!!!!!!!!!!!!!!!!!!!!!!!!
     emission = bremsstrahlung;
-    # !!!!!!!!!!!!!!!!!!!!!!!!!!!
-    # !!!!!!!!!!!!!!!!!!!!!!!!!!!
+    #Different elements and their number-densities can be speciefied as Z and n respectively. Defeault is Z = 1, n =1
+
 }
 @RadiationOutput image {
     pixels = 600;

--- a/examples/Bremsstrahlung_screened/pi
+++ b/examples/Bremsstrahlung_screened/pi
@@ -53,15 +53,11 @@ tools              = rad;
 }
 
 @RadiationModel cone {
-    # !!!!!!!!!!!!!!!!!!!!!!!!!!!
-    # This is the only setting
-    # specific to bremsstrahlung
-    # !!!!!!!!!!!!!!!!!!!!!!!!!!!
     emission = bremsstrahlung_screened;
     #Input if bremsstrahlung_screened is used, can be ignored otherwise
     Z = 10, 18;
     Z0 = 2, 2;
-    n = 1e19, 2e19;
+    n = 1e19, 1e19;
     
 }
 @RadiationOutput image {

--- a/examples/plotspectrum.py
+++ b/examples/plotspectrum.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+#
+# Loads a raw SOFT spectrum and plots it.
+# The first command-line argument gives the name of
+# the SOFT output file to load. If a second argument
+# is given, the generated figure is saved to a file
+# with the name specified by the second argument.
+# Otherwise, if no argument is given, the figure is
+# shown on screen.
+#
+# ./plotspectrum.py infile [outfile]
+#
+# infile     -- Name of input file (i.e. SOFT output image)
+# outfile    -- Optional. If given, saves the generated
+#               figure to a file with name 'outfile'.
+#
+# By: Olle Lexell, 2019
+###############################
+
+import numpy as np
+import matplotlib.pyplot as plt
+import h5py
+import sys
+import gerimap
+import matplotlib.ticker
+
+def loadImage(filename):
+    """
+    Loads wavelengths and intebsity from a SOFT spectrum
+    output file (in HDF5 or MATv7.3 format)
+
+    filename: Name of file to load
+    """
+    image = None
+
+    with h5py.File(filename, 'r') as f:
+        wl = f['wavelengths'][:].T
+        Pow = f['I'][:].T
+    return wl, Pow
+
+
+def plotImage(wl, Pow):
+    """
+    Plot a SOFT spectrum.
+
+    wl = wavelengths, Pow = intensity
+    """
+    plt.rc('text', usetex=True)
+    plt.rc('font', family='serif')
+
+    fig = plt.figure()
+    
+    ax = fig.add_subplot(111)
+    ax.plot(wl, wl*Pow, color='C0')
+    ax.set_title("Bremsstrahlung cross section, no screening, formula 3BN")
+    
+    
+    ax.set_xlabel("$k$ normalized to $m_ec$")
+    ax.set_ylabel("$k \cdot \partial \sigma/\partial k$")
+
+    return ax, fig
+
+def saveFigure(ax, fig, outname):
+    """
+    Save the plotted figure to a file.
+
+    ax:      Matplotlib axis object.
+    fig:     Matplotlib figure object.
+    outname: Name of file to save figure to.
+    """
+    ax.set_axis_off()
+    fig.subplots_adjust(top=1, bottom=0, right=1, left=0, hspace=0, wspace=0)
+
+    ax.get_xaxis().set_major_locator(matplotlib.ticker.NullLocator())
+    ax.get_yaxis().set_major_locator(matplotlib.ticker.NullLocator())
+
+    fcolor = fig.patch.get_facecolor()
+
+    fig.canvas.print_figure(outname, bbox_inches='tight', pad_inches=0, facecolor=fcolor, dpi=600)
+
+
+def plothelp():
+    print("./plotimage.py infile [outfile]")
+    print("\nPlot a SOFT radiation image")
+    print("infile     -- Name of input SOFT image (in HDF5/MATv7.3 format)")
+    print("outfile    -- (optional) Name of output image. Filename extension")
+    print("              determines the file type. Any file type supported by")
+    print("              matplotlib can be used (common: PDF, PNG, EPS).")
+
+def main(argv):
+    infile  = None
+    outfile = None
+
+    if len(argv) >= 1:
+        infile = argv[0]
+    if len(argv) == 2:
+        outfile = argv[1]
+    if len(argv) > 2 or len(argv) == 0:
+        print('ERROR: Too many command-line arguments given.')
+        plothelp()
+        sys.exit(-1)
+
+    wl, Pow   = loadImage(infile)
+    ax, fig = plotImage(wl, Pow)
+
+    if outfile is not None:
+        saveFigure(ax, fig, outfile)
+    else:
+        plt.show()
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])
+

--- a/include/Tools/Radiation/Models/Cone/ConeBremsstrahlungEmission.h
+++ b/include/Tools/Radiation/Models/Cone/ConeBremsstrahlungEmission.h
@@ -23,13 +23,12 @@ namespace __Radiation {
             static constexpr slibreal_t r02Alpha = 
                 _e2*_e2*alpha / (16.0*M_PI*M_PI*EPS0*EPS0*_m2*_c2*_c2);
 
-            slibreal_t Z2;      // Square of effective plasma charge
+            unsigned int nspecies;
+            slibreal_t *Z;
+            slibreal_t *density;
         public:
-            ConeBremsstrahlungEmission(Detector *det, MagneticField2D *mf, const slibreal_t Zeff)
-                : ConeEmission(det, mf) {
-                this->Z2 = Zeff*Zeff;
-            };
-            ~ConeBremsstrahlungEmission() {}
+            ConeBremsstrahlungEmission(Detector *det, MagneticField2D *mf, unsigned int nspecies, slibreal_t *Z, slibreal_t *density);
+            ~ConeBremsstrahlungEmission();
 
             void HandleParticle(RadiationParticle*, bool);
 

--- a/include/Tools/Radiation/Models/Cone/ConeBremsstrahlungScreenedEmission.h
+++ b/include/Tools/Radiation/Models/Cone/ConeBremsstrahlungScreenedEmission.h
@@ -20,13 +20,14 @@ namespace __Radiation {
 #define _m2 (_m*_m)
             static constexpr slibreal_t alpha =
                 _e*_e / (4.0*M_PI*EPS0*_c*HBAR);
+            static constexpr slibreal_t r02 = 
+                _e2*_e2 / (16.0*M_PI*M_PI*EPS0*EPS0*_m2*_c2*_c2);
             static constexpr slibreal_t r02Alpha = 
-                _e2*_e2*alpha / (16.0*M_PI*M_PI*EPS0*EPS0*_m2*_c2*_c2);
+                r02*alpha;
             unsigned int nspecies;
             slibreal_t *Z;
             slibreal_t *Z0;
             slibreal_t *density;
-            slibreal_t r02;
 
             double qagsEpsAbs=0.0,
                    qagsEpsRel=1e-3;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -151,6 +151,7 @@ set(tool_radiation_tests
     "${PROJECT_SOURCE_DIR}/tests/deep/Tools/Radiation/Models/Cone/Test_ConeProjection.cpp"
     "${PROJECT_SOURCE_DIR}/tests/deep/Tools/Radiation/Models/Cone/Test_SynchrotronEmission.cpp"
     "${PROJECT_SOURCE_DIR}/tests/deep/Tools/Radiation/Models/Cone/Bremsstrahlung/Test_BremsstrahlungScreenedEmission.cpp"
+    "${PROJECT_SOURCE_DIR}/tests/deep/Tools/Radiation/Models/Cone/Bremsstrahlung/Test_BremsstrahlungEmission.cpp"
     "${PROJECT_SOURCE_DIR}/tests/deep/Tools/Radiation/Models/Cone/Reverse/Test_ConeProjectionReverse.cpp"
 )
 

--- a/src/Tools/Radiation/Models/Cone/Configure.cpp
+++ b/src/Tools/Radiation/Models/Cone/Configure.cpp
@@ -66,9 +66,9 @@ void Cone::ConfigureEmission(const string& emname, ConfigBlock *conf) {
 
         //default values
         slibreal_t *Z = new slibreal_t[1];
-        Z[1] = 1.0;
+        Z[0] = 1.0;
         slibreal_t *density = new slibreal_t[1];
-        density[1] = 1.0;
+        density[0] = 1.0;
         unsigned int nspecies = 1;
       
     	// Reading Z's and number-desities from pi-file
@@ -77,7 +77,8 @@ void Cone::ConfigureEmission(const string& emname, ConfigBlock *conf) {
             if (!s->IsNumericVector())
                 throw ConeException("Invalid value assigned to paramter 'Z'. Expected real vector. If no Z-values are given, Z=1 by defualt.");
             vector Z_vec = s->GetNumericVector();
-            nspecies = Z_vec.size(); 
+            nspecies = Z_vec.size();
+            delete []Z;
             Z = new slibreal_t [nspecies];
             
             for(unsigned int i = 0; i < nspecies; i++)
@@ -91,6 +92,7 @@ void Cone::ConfigureEmission(const string& emname, ConfigBlock *conf) {
             vector n_vec = s2->GetNumericVector();
             if(n_vec.size() != nspecies)
                 throw ConeException("Number of n-values do not match number of Z-values. If no n-values are given, n=1 by defualt.");
+            delete []density;
             density = new slibreal_t [nspecies];
 
             for(unsigned int i = 0; i < nspecies; i++)

--- a/src/Tools/Radiation/Models/Cone/Configure.cpp
+++ b/src/Tools/Radiation/Models/Cone/Configure.cpp
@@ -64,16 +64,40 @@ void Cone::ConfigureEmission(const string& emname, ConfigBlock *conf) {
         if (this->parent->MeasuresPolarization())
             throw ConeBremsstrahlungException("The bremsstrahlung radiation model does not support polarization measurements.");
 
-    	// zeff (must be set before 'emission' model
-        slibreal_t Zeff = 1;
-        if (conf->HasSetting("zeff")) {
-            Setting *s = conf->GetSetting("zeff");
-            if (!s->IsScalar())
-                throw ConeException("Invalid value assigned to paramter 'zeff'. Expected real scalar.");
+        //default values
+        slibreal_t *Z = new slibreal_t[1];
+        Z[1] = 1.0;
+        slibreal_t *density = new slibreal_t[1];
+        density[1] = 1.0;
+        unsigned int nspecies = 1;
+      
+    	// Reading Z's and number-desities from pi-file
+        if (conf->HasSetting("Z")) {
+            Setting *s = conf->GetSetting("Z");
+            if (!s->IsNumericVector())
+                throw ConeException("Invalid value assigned to paramter 'Z'. Expected real vector. If no Z-values are given, Z=1 by defualt.");
+            vector Z_vec = s->GetNumericVector();
+            nspecies = Z_vec.size(); 
+            Z = new slibreal_t [nspecies];
             
-            Zeff = s->GetScalar();
+            for(unsigned int i = 0; i < nspecies; i++)
+                Z[i] = Z_vec[i];
         }
-        this->emission = new ConeBremsstrahlungEmission(this->parent->detector, this->parent->magfield, Zeff);
+
+        if (conf->HasSetting("n")) {
+            Setting *s2 = conf->GetSetting("n");
+            if (!s2->IsNumericVector())
+                throw ConeException("Invalid value assigned to paramter 'n'. Expected real vector. If no n-values are given, n=1 by default.");
+            vector n_vec = s2->GetNumericVector();
+            if(n_vec.size() != nspecies)
+                throw ConeException("Number of n-values do not match number of Z-values. If no n-values are given, n=1 by defualt.");
+            density = new slibreal_t [nspecies];
+
+            for(unsigned int i = 0; i < nspecies; i++)
+                density[i] = n_vec[i];
+        }
+
+        this->emission = new ConeBremsstrahlungEmission(this->parent->detector, this->parent->magfield, nspecies, Z, density); //New arguments
     } else if (emname == "bremsstrahlung_screened") {
     
         if (!conf->HasSetting("Z"))

--- a/src/Tools/Radiation/Models/Cone/Emission/Bremsstrahlung/ConeBremsstrahlungEmission.cpp
+++ b/src/Tools/Radiation/Models/Cone/Emission/Bremsstrahlung/ConeBremsstrahlungEmission.cpp
@@ -83,7 +83,7 @@ void ConeBremsstrahlungEmission::CalculateSpectrum(RadiationParticle *rp) {
         p = sqrt(p2);
 
         eps  = 2.0*log(E+p);
-        eps0 = 2.0*log(gamma+p);
+        eps0 = 2.0*log(gamma+p0);
 
         TT2 =-2.0*gamma*E*(p2 + p02)/(p2*p02);
         TT3 = eps0*E/(p02*p0);

--- a/src/Tools/Radiation/Models/Cone/Emission/Bremsstrahlung/ConeBremsstrahlungEmission.cpp
+++ b/src/Tools/Radiation/Models/Cone/Emission/Bremsstrahlung/ConeBremsstrahlungEmission.cpp
@@ -59,7 +59,7 @@ void ConeBremsstrahlungEmission::CalculateTotalEmission(RadiationParticle *rp) {
         T3 =-4.0/3.0,
         T4 = 2.0 / gp0 * dilog_func(2.0*(gp0 + p02));
     for(unsigned int j = 0; j < nspecies; j++){
-        pf = pf + density[j]*Z[j]*Z[j]*this->r02Alpha;
+        pf += density[j]*Z[j]*Z[j]*this->r02Alpha;
     }
 
     this->power = pf * (T1 + T2 + T3 + T4);
@@ -85,7 +85,7 @@ void ConeBremsstrahlungEmission::CalculateSpectrum(RadiationParticle *rp) {
         E, E2, p, p2, k, eps, eps0;
     
     for (unsigned int j = 0; j < nspecies; j++)
-        pf = pf + density[j]*Z[j]*Z[j] * this->r02Alpha;
+        pf += density[j]*Z[j]*Z[j] * this->r02Alpha;
 
     for (unsigned int i = 0; i < nwavelengths; i++) {
         k = wavelengths[i];

--- a/src/Tools/Radiation/Models/Cone/Emission/Bremsstrahlung/ConeBremsstrahlungScreenedEmission.cpp
+++ b/src/Tools/Radiation/Models/Cone/Emission/Bremsstrahlung/ConeBremsstrahlungScreenedEmission.cpp
@@ -60,9 +60,8 @@ void ConeBremsstrahlungScreenedEmission::CalculateTotalEmission() {
  * Calculate eq. 4BS (Koch & Motz) for a given species
  */
 slibreal_t ConeBremsstrahlungScreenedEmission::Calculate4BS(slibreal_t Z) {
-    slibreal_t Z2fakt = 4*Z*Z*r02Alpha;
+    slibreal_t Z2fakt = 4*Z*Z*r02/137;
     slibreal_t lnfakt = log(183) - 0.5*log(Z) + 0.0555555555555556;
-    
     return Z2fakt*lnfakt;
 }
 

--- a/src/Tools/Radiation/Models/Cone/Emission/Bremsstrahlung/ConeBremsstrahlungScreenedEmission.cpp
+++ b/src/Tools/Radiation/Models/Cone/Emission/Bremsstrahlung/ConeBremsstrahlungScreenedEmission.cpp
@@ -59,7 +59,7 @@ void ConeBremsstrahlungScreenedEmission::CalculateTotalEmission() {
  * Calculate eq. 4BS (Koch & Motz) for a given species
  */
 slibreal_t ConeBremsstrahlungScreenedEmission::Calculate4BS(slibreal_t Z) {
-    slibreal_t Z2fakt = 4*Z*Z*r02/137;
+    slibreal_t Z2fakt = 4*Z*Z*r02Alpha;
     slibreal_t lnfakt = log(183) - 0.5*log(Z) + 0.0555555555555556;
     return Z2fakt*lnfakt;
 }

--- a/src/Tools/Radiation/Models/Cone/Emission/Bremsstrahlung/ConeBremsstrahlungScreenedEmission.cpp
+++ b/src/Tools/Radiation/Models/Cone/Emission/Bremsstrahlung/ConeBremsstrahlungScreenedEmission.cpp
@@ -29,10 +29,9 @@ ConeBremsstrahlungScreenedEmission::~ConeBremsstrahlungScreenedEmission() {
 
 
 /**
- * Calculates the total emission and/or spectrum and/or
- * Stokes parameters of synchrotron radiation.
+ * Calculates the total emission and/or spectrum
  *
- * rp:           Object representing particle emitting state.
+ * rp: Object representing particle emitting state.
  * 
  */
 void ConeBremsstrahlungScreenedEmission::HandleParticle(RadiationParticle *rp, bool) {

--- a/tests/deep/Tools/Radiation/Models/Cone/Bremsstrahlung/GenerateTable.m
+++ b/tests/deep/Tools/Radiation/Models/Cone/Bremsstrahlung/GenerateTable.m
@@ -59,7 +59,7 @@ Final_table_3BN = [Z; dens; gamma; Integrated_spectrum]';
 %% Functions
 
 function val = Get_4BS(Z, r0)
-    Z2fakt = 4*Z^2*r0^2/137;
+    Z2fakt = 4*Z^2*r0^2*alpha;
     lnfakt = log(183) - 0.5*log(Z)+1/18;
     val = Z2fakt*lnfakt;
 end

--- a/tests/deep/Tools/Radiation/Models/Cone/Bremsstrahlung/GenerateTable.m
+++ b/tests/deep/Tools/Radiation/Models/Cone/Bremsstrahlung/GenerateTable.m
@@ -42,19 +42,19 @@ Final_table_spec = [gamma; Integrated_spectrum]';
 wl_fin = wl;
 %% Table for 3BN
 clc; format long;
-Zeff = [2 7 10 15];
+Z = [2 7 10 15];
+dens = [1.649e19 11.467e19 7.3903e19 9.1003e19];
 gamma = [5 13 38 67];
-Integrated_spectrum = zeros(numel(Zeff), numel(gamma));
+Integrated_spectrum = zeros(1, numel(gamma));
 wl = linspace(1, 50, 50);
 
-for j=1:numel(Zeff)
+
 for i=1:length(gamma)
-    spectrum = spec_3BN(Zeff(j), wl, gamma(i), r0, alpha);
-    Integrated_spectrum(j,i) = Integrate_spectrum(spectrum, wl);
-end
+    spectrum = spec_3BN(Z, dens, wl, gamma(i), r0, alpha);
+    Integrated_spectrum(i) = Integrate_spectrum(spectrum, wl);
 end
 
-Final_table_3BN = [Zeff; gamma]';
+Final_table_3BN = [Z; dens; gamma; Integrated_spectrum]';
 
 %% Functions
 
@@ -119,11 +119,8 @@ function Int_spec = Integrate_spectrum(spec, wl)
     Int_spec = Int*(wl(2)-wl(1));
 end
 
-function spec= spec_3BN(Zeff, wl, gamma_in, r0, alpha)
+function spec= spec_3BN(Z, dens, wl, gamma_in, r0, alpha)
     nr_wl = numel(wl);
-    %if length(gamma_in) == 1
-    %gamma_in = gamma_in*ones(1, nr_wl);
-    %end
     d1sigma = zeros(1,nr_wl);
     for i=1:nr_wl
         k = wl(i);
@@ -156,7 +153,7 @@ function spec= spec_3BN(Zeff, wl, gamma_in, r0, alpha)
 
         d1sigma(i) = PreFactor .* ( Term1 + Term2 + Term3 ); %.*(k<(E0-1));
     end
-        spec =  Zeff^2*d1sigma;
+        spec =  (dens*(Z.^2)')*d1sigma;
 end
 
 %function pow = power(nspecies, Z, density, r0) %Needed for testung 4BS,

--- a/tests/deep/Tools/Radiation/Models/Cone/Bremsstrahlung/Test_BremsstrahlungEmission.cpp
+++ b/tests/deep/Tools/Radiation/Models/Cone/Bremsstrahlung/Test_BremsstrahlungEmission.cpp
@@ -1,0 +1,188 @@
+/**
+ * Test of the bremsstrahlung screned emission implemented in the cone model.
+ * The following tests are included:
+ *
+ *   [ ] - Emission formulas (Only integrated spectrum).  
+ *
+ */
+
+#include "Tools/Radiation/RadiationParticle.h"
+#include "Tools/Radiation/Models/Cone/ConeBremsstrahlungEmission.h"
+#include "Test_BremsstrahlungEmission.h"
+
+using namespace std;
+using namespace __Radiation;
+
+//Constants used to retrive data from tables
+const unsigned int 
+    IGAMMA = 1,
+    IZEFF = 0;
+
+const unsigned int Test_BremsstrahlungEmission::NTESTVALUES = 4;
+
+const slibreal_t Test_BremsstrahlungEmission::TEST_ZEFF_GAMMA[4][2] = {
+{2,	    5},
+{7,     13},
+{10,    38},
+{15,	67}
+};
+
+const slibreal_t Test_BremsstrahlungEmission::TEST_VAL[NTESTVALUES][NTESTVALUES] = {
+{2.88228628200495e-30,	9.39765963487424e-30,	2.10302400717392e-29,	2.84214668681879e-29},
+{3.53080069545606e-29,	1.15121330527209e-28,	2.57620440878806e-28,	3.48162969135301e-28},
+{7.20571570501237e-29,	2.34941490871856e-28,	5.25756001793481e-28,	7.10536671704696e-28},
+{1.62128603362778e-28,	5.28618354461676e-28,	1.18295100403533e-27,	1.59870751133557e-27}
+};
+
+
+/**
+ * Check that the formula for total emission
+ * of synchrotron radiation has been implemented
+ * correctly. Tests vs values obtained from same formulas implemented in matlab
+ */
+/*bool Test_BremsstrahlungEmission::CheckTotalEmission(const slibreal_t tol) {
+    unsigned int i;
+    Detector *det = GetDetector(0);
+    slibreal_t pwr, corr, Delta;
+
+    for (i = 0; i < NTESTVALUES; i++) {
+	    slibreal_t Input_Z[6] = {TEST_Z[i][0], TEST_Z[i][1], TEST_Z[i][2], TEST_Z[i][3], TEST_Z[i][4], TEST_Z[i][5]};
+        slibreal_t Input_DENS[6] = {TEST_DENS[i][0], TEST_DENS[i][1], TEST_DENS[i][2], TEST_DENS[i][3], TEST_DENS[i][4], TEST_DENS[i][5]};
+        slibreal_t Input_Z0[6] = {TEST_Z0[i][0], TEST_Z0[i][1], TEST_Z0[i][2], TEST_Z0[i][3], TEST_Z0[i][4], TEST_Z0[i][5]};
+        ConeBremsstrahlungEmission cbse(det, nullptr, TEST_NR_POW[i].nspecies, Input_Z, Input_Z0, Input_DENS);
+
+        cbse.CalculateTotalEmission();
+        pwr = cbse.GetTotalEmission();
+        corr = TEST_NR_POW[i].val;
+        
+        Delta = fabs((pwr-corr)/corr);
+
+        if (Delta >= tol) {
+            this->PrintError("Total bremsstrahlung  emission was not calculated correctly. Delta = %e", Delta);
+            return false;
+        }
+    }
+    return true;
+}*/
+
+/* 
+ * Test so that the spectrum integrates to the correct value
+ */
+bool Test_BremsstrahlungEmission::CheckSpectrumEmission(const slibreal_t tol) {
+    
+    unsigned int i, j;
+    Detector *det = GetDetector(50, 1, 50); //Gives detector and defines which photon momenta to look at
+    MagneticFieldAnalytical2D *dummy_mf = GetMagneticField();
+    slibreal_t pwr, corr, Delta;
+
+    /*slibreal_t *Z = new slibreal_t[nspecies],
+    *Z0 = new slibreal_t[nspecies], 
+    *DENS = new slibreal_t[nspecies];
+    for (i = 0; i < nspecies; i++){
+        Z[i] = TEST_Z[NTESTVALUES-1][i];
+        Z0[i] = TEST_Z0[NTESTVALUES-1][i];
+        DENS[i] = TEST_DENS[NTESTVALUES-1][i];
+    }*/
+    for (j = 0; j < NTESTVALUES; j++) {
+        ConeBremsstrahlungEmission cbe(det, nullptr, TEST_ZEFF_GAMMA[j][IZEFF]);
+        for (i = 0; i < NTESTVALUES; i++) {
+            
+            RadiationParticle *rp = GetRadiationParticle(i, det, dummy_mf);
+            
+            cbe.CalculateSpectrum(rp);
+            cbe.IntegrateSpectrum();
+            pwr = cbe.GetTotalEmission();
+            corr = TEST_VAL[j][i];
+
+            
+            Delta = fabs((pwr-corr)/corr);
+
+            if (Delta >= tol) {
+                this->PrintError("Total bremsstrahlung emission was not calculated correctly. Delta = %e", Delta);
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+/**
+ * Returns a sample detector.
+ */
+Detector *Test_BremsstrahlungEmission::GetDetector(unsigned int nwavelengths, slibreal_t l0, slibreal_t l1) {
+    const slibreal_t
+        aperture = 0.006,
+        visang   = 1.0,
+        dir[3] = {0.0,1.0,0.0},
+        pos[3] = {0.0,-1.069,0.0};
+        
+    Vector<3>
+        direction(dir),
+        position(pos);
+
+    return new Detector(aperture, visang, direction, position, nwavelengths, l0, l1);
+}
+
+/**
+ * Returns the pre-defined RadiationParticle object
+ * with index 'i'.
+ *
+ * i: Index in table 'predef_particles' with pre-defined
+ *    particle parameters to test, in this case gamma.
+ */
+RadiationParticle *Test_BremsstrahlungEmission::GetRadiationParticle(unsigned int i, Detector *det, MagneticFieldAnalytical2D *mf) {
+    if (i >= NTESTVALUES)
+        throw SOFTException("Trying to access non-existant test-value.");
+
+    Vector<3> x, //Arbitrary position
+		rhat = x-det->GetPosition(),
+		Bvec = mf->Eval(x[0], x[1], x[2]),
+		bHat = Bvec;
+
+	bHat.Normalize();
+	rhat.Normalize();
+		
+
+    slibreal_t
+        Jdtdrho = 1.0,
+        gamma = TEST_ZEFF_GAMMA[i][IGAMMA],
+        p2 = gamma*gamma - 1.0,
+        p  = sqrt(p2),
+        cosThetap = rhat.Dot(bHat),
+        sinThetap = sqrt(1.0 - cosThetap*cosThetap),
+        ppar = p * cosThetap,
+        pperp = p * sinThetap,
+        B = Bvec.Norm(),
+        m = ELECTRON_MASS, q = -ELEMENTARY_CHARGE;
+		
+    Vector<3> P = p*rhat;
+
+    return new RadiationParticle(
+        x, P,
+        Jdtdrho, ppar, pperp,
+        gamma, p2, det->GetPosition(),
+        B, Bvec, bHat, m, q, 0, 0, 0
+    );
+}
+
+/**
+ * Run all the tests in the module.
+ */
+bool Test_BremsstrahlungEmission::Run(bool) {
+    bool success = true;
+    //slibreal_t TOTEM_TOL=SQRT_REAL_EPSILON;
+    slibreal_t SPECT_TOL=1e-3;
+
+    /*if (CheckTotalEmission(TOTEM_TOL))
+        this->PrintOK("Total emission is implemented correctly.");
+    else
+        success = false;*/
+
+    if (CheckSpectrumEmission(SPECT_TOL))
+        this->PrintOK("Spectrum integrates correctly.");
+    else
+        success = false;
+    
+    return success;
+}
+

--- a/tests/deep/Tools/Radiation/Models/Cone/Bremsstrahlung/Test_BremsstrahlungEmission.h
+++ b/tests/deep/Tools/Radiation/Models/Cone/Bremsstrahlung/Test_BremsstrahlungEmission.h
@@ -1,0 +1,24 @@
+#ifndef _TEST_BREMSSTRHLUNG_EMISSION_H
+#define _TEST_BREMSSTRAHLUNG_EMISSION_H
+
+#include <softlib/config.h>
+#include "Tools/Radiation/RadiationParticle.h"
+#include "../../../../../UnitTest.h"
+
+class Test_BremsstrahlungEmission : public UnitTest {
+    private:
+        static const unsigned int NTESTVALUES;
+        static const slibreal_t TEST_ZEFF_GAMMA[][2];
+        
+        static const slibreal_t TEST_VAL[][4];
+    public:
+        Test_BremsstrahlungEmission(const string& msg) : UnitTest(msg) { }
+
+        //bool CheckTotalEmission(const slibreal_t);
+        bool CheckSpectrumEmission(const slibreal_t);
+        __Radiation::Detector *GetDetector(unsigned int, slibreal_t l0=4e-7, slibreal_t l1=1e-6);
+        __Radiation::RadiationParticle *GetRadiationParticle(unsigned int, __Radiation::Detector*, MagneticFieldAnalytical2D*);
+        bool Run(bool);
+};
+
+#endif/*_TEST_BREMSSTRAHLUNG_EMISSION_H*/

--- a/tests/deep/Tools/Radiation/Models/Cone/Bremsstrahlung/Test_BremsstrahlungEmission.h
+++ b/tests/deep/Tools/Radiation/Models/Cone/Bremsstrahlung/Test_BremsstrahlungEmission.h
@@ -8,9 +8,7 @@
 class Test_BremsstrahlungEmission : public UnitTest {
     private:
         static const unsigned int NTESTVALUES;
-        static const slibreal_t TEST_ZEFF_GAMMA[][2];
-        
-        static const slibreal_t TEST_VAL[][4];
+        static const slibreal_t TEST_VALUES[][4];
     public:
         Test_BremsstrahlungEmission(const string& msg) : UnitTest(msg) { }
 

--- a/tests/deep/Tools/Radiation/Models/Cone/Bremsstrahlung/Test_BremsstrahlungScreenedEmission.cpp
+++ b/tests/deep/Tools/Radiation/Models/Cone/Bremsstrahlung/Test_BremsstrahlungScreenedEmission.cpp
@@ -40,7 +40,7 @@ const slibreal_t Test_BremsstrahlungScreenedEmission::TEST_DENS[NTESTVALUES][6] 
 };
 
 struct TESTDATA {unsigned int nspecies; slibreal_t val;};
-const struct TESTDATA TEST_NR_POW[10] = {
+/*const struct TESTDATA TEST_NR_POW[10] = {
 {1, 6.73045973479381e-10},
 {1, 2.01662976950185e-09},
 {2, 1.13293399609858e-09},
@@ -51,6 +51,18 @@ const struct TESTDATA TEST_NR_POW[10] = {
 {5, 8.02396169262980e-09},
 {6, 4.54479515488073e-09},
 {6, 3.45373484297087e-09}
+};*/
+const struct TESTDATA TEST_NR_POW[10] = {
+{1,	6.72869164594994e-10},
+{1,	2.01610000173885e-09},
+{2,	1.13263637483075e-09},
+{2,	2.50815825302217e-09},
+{4,	7.60786590289521e-09},
+{4,	5.86728992348359e-09},
+{5,	1.57554524643507e-08},
+{5,	8.02185380138442e-09},
+{6,	4.54360123917101e-09},
+{6,	3.45282754833036e-09}
 };
 
 const slibreal_t Test_BremsstrahlungScreenedEmission::TEST_GAMMA_INTSPEC[NTESTVALUES][2] = {

--- a/tests/deep/Tools/Radiation/Models/Cone/Bremsstrahlung/Test_BremsstrahlungScreenedEmission.cpp
+++ b/tests/deep/Tools/Radiation/Models/Cone/Bremsstrahlung/Test_BremsstrahlungScreenedEmission.cpp
@@ -77,7 +77,7 @@ bool Test_BremsstrahlungScreenedEmission::CheckTotalEmission(const slibreal_t to
     slibreal_t pwr, corr, Delta;
 
     for (i = 0; i < NTESTVALUES; i++) {
-	    slibreal_t Input_Z[6] = {TEST_Z[i][0], TEST_Z[i][1], TEST_Z[i][2], TEST_Z[i][3], TEST_Z[i][4], TEST_Z[i][5]};
+        slibreal_t Input_Z[6] = {TEST_Z[i][0], TEST_Z[i][1], TEST_Z[i][2], TEST_Z[i][3], TEST_Z[i][4], TEST_Z[i][5]};
         slibreal_t Input_DENS[6] = {TEST_DENS[i][0], TEST_DENS[i][1], TEST_DENS[i][2], TEST_DENS[i][3], TEST_DENS[i][4], TEST_DENS[i][5]};
         slibreal_t Input_Z0[6] = {TEST_Z0[i][0], TEST_Z0[i][1], TEST_Z0[i][2], TEST_Z0[i][3], TEST_Z0[i][4], TEST_Z0[i][5]};
         ConeBremsstrahlungScreenedEmission cbse(det, nullptr, TEST_NR_POW[i].nspecies, Input_Z, Input_Z0, Input_DENS);

--- a/tests/deep/Tools/Radiation/Models/Cone/Bremsstrahlung/Test_BremsstrahlungScreenedEmission.h
+++ b/tests/deep/Tools/Radiation/Models/Cone/Bremsstrahlung/Test_BremsstrahlungScreenedEmission.h
@@ -12,7 +12,6 @@ class Test_BremsstrahlungScreenedEmission : public UnitTest {
         static const slibreal_t TEST_Z0[][6];
         static const slibreal_t TEST_DENS[][6];
         static const slibreal_t TEST_GAMMA_INTSPEC[][2];
-        const slibreal_t ANGDIST_TOL = 10.0*SQRT_REAL_EPSILON;
     public:
         Test_BremsstrahlungScreenedEmission(const string& msg) : UnitTest(msg) { }
 

--- a/tests/deep/runtest.cpp
+++ b/tests/deep/runtest.cpp
@@ -21,7 +21,8 @@
 #include "Tools/Radiation/Models/AngularDistribution/Test_AngularDistributionDrifts.h"
 #include "Tools/Radiation/Models/Cone/Test_ConeProjection.h"
 #include "Tools/Radiation/Models/Cone/Test_SynchrotronEmission.h"
-#include "Tools/Radiation/Models/Cone/Bremsstrahlung/Test_BremsstrahlungScreenedEmission.h" // new bremsstrahlung test
+#include "Tools/Radiation/Models/Cone/Bremsstrahlung/Test_BremsstrahlungScreenedEmission.h"
+#include "Tools/Radiation/Models/Cone/Bremsstrahlung/Test_BremsstrahlungEmission.h"
 #include "Tools/Radiation/Models/Cone/Reverse/Test_ConeProjectionReverse.h"
 #include "Tools/Radiation/Models/Isotropic/Test_Isotropic.h"
 
@@ -44,8 +45,9 @@ void init() {
     add_test(new Test_ConeProjection("radiation_model_cone_projection"));
     add_test(new Test_ConeProjectionReverse("radiation_model_cone_projection_reverse"));
     add_test(new Test_SynchrotronEmission("radiation_model_cone_synchrotron"));
-    add_test(new Test_BremsstrahlungScreenedEmission("radiation_model_cone_bremsstrahlung_screened")); //new bremsstrahlung test
+    add_test(new Test_BremsstrahlungScreenedEmission("radiation_model_cone_bremsstrahlung_screened")); 
     add_test(new Test_Isotropic("radiation_model_isotropic"));
+    add_test(new Test_BremsstrahlungEmission("radiation_model_cone_bremsstrahlung"));
 }
 
 /**


### PR DESCRIPTION
Changed unscreened bremsstrahlung to account for different elements and densities, instead of using a Z_eff, which gave a faulty spectrum. Also fixed calculation error in implementation of 3BN and implemented test for integrated spectra in unscreened case.