### PR TITLE
Setting rel. error tol. for QAGS

### DIFF
--- a/examples/Bremsstrahlung_screened/pi
+++ b/examples/Bremsstrahlung_screened/pi
@@ -58,6 +58,7 @@ tools              = rad;
     Z = 10, 18;
     Z0 = 2, 2;
     n = 1e19, 1e19;
+    QAGS_EpsRel = 1e-3; #Rel error tolerance for QAGS, defualt is 1e-3
     
 }
 @RadiationOutput image {

--- a/examples/Bremsstrahlung_screened/pi
+++ b/examples/Bremsstrahlung_screened/pi
@@ -58,7 +58,7 @@ tools              = rad;
     Z = 10, 18;
     Z0 = 2, 2;
     n = 1e19, 1e19;
-    QAGS_EpsRel = 1e-3; #Rel error tolerance for QAGS, defualt is 1e-3
+    qagstol = 1e-3; #Rel error tolerance for QAGS, defualt is 1e-3
     
 }
 @RadiationOutput image {

--- a/examples/plotspectrum.py
+++ b/examples/plotspectrum.py
@@ -52,11 +52,11 @@ def plotImage(wl, Pow):
     
     ax = fig.add_subplot(111)
     ax.plot(wl, wl*Pow, color='C0')
-    ax.set_title("Bremsstrahlung cross section, no screening, formula 3BN")
+    ax.set_title("Title")
     
     
-    ax.set_xlabel("$k$ normalized to $m_ec$")
-    ax.set_ylabel("$k \cdot \partial \sigma/\partial k$")
+    ax.set_xlabel("$x-axis$")
+    ax.set_ylabel("$y-axis$")
 
     return ax, fig
 

--- a/include/Tools/Radiation/Models/Cone/ConeBremsstrahlungScreenedEmission.h
+++ b/include/Tools/Radiation/Models/Cone/ConeBremsstrahlungScreenedEmission.h
@@ -30,12 +30,12 @@ namespace __Radiation {
             slibreal_t *density;
 
             double qagsEpsAbs=0.0,
-                   qagsEpsRel=1e-3;
+                   qagsEpsRel;
             std::size_t qagsLimit = 100;
             gsl_integration_workspace *qagsWS = nullptr;
 
        public:
-            ConeBremsstrahlungScreenedEmission(Detector *det, MagneticField2D *mf, unsigned int nspecies, slibreal_t *Z, slibreal_t *Z0, slibreal_t *density);
+            ConeBremsstrahlungScreenedEmission(Detector *det, MagneticField2D *mf, unsigned int nspecies, slibreal_t *Z, slibreal_t *Z0, slibreal_t *density, slibreal_t QAGSEpsRel);
             ~ConeBremsstrahlungScreenedEmission();
 
             void HandleParticle(RadiationParticle*, bool);

--- a/src/Tools/Radiation/Models/Cone/Configure.cpp
+++ b/src/Tools/Radiation/Models/Cone/Configure.cpp
@@ -138,26 +138,26 @@ void Cone::ConfigureEmission(const string& emname, ConfigBlock *conf) {
             Z0[i] = Z0_vec[i];
             density[i] = n_vec[i];
         }
-        slibreal_t qagsEpsRel = 1e-3;
-        if (conf->HasSetting("QAGS_EpsRel")){
-            Setting *s =conf->GetSetting("QAGS_EpsRel");
+        slibreal_t qagstol = 1e-3;
+        if (conf->HasSetting("qagstol")){
+            Setting *s =conf->GetSetting("qagstol");
             if (!s->IsScalar())
-                throw ConeException("Invalid value assigned to parameter QAGS_EpsRel, expected real scalar");
-            qagsEpsRel = s->GetScalar();
+                throw ConeException("Invalid value assigned to parameter qagstol, expected real scalar");
+            qagstol = s->GetScalar();
         }
-        this->emission = new ConeBremsstrahlungScreenedEmission(this->parent->detector, this->parent->magfield, nspecies, Z, Z0, density, qagsEpsRel);
+        this->emission = new ConeBremsstrahlungScreenedEmission(this->parent->detector, this->parent->magfield, nspecies, Z, Z0, density, qagstol);
     }
     else if (emname == "synchrotron") {
-            this->emission = new ConeSynchrotronEmission(this->parent->detector, this->parent->magfield, this->parent->MeasuresPolarization());
-        } else if (emname == "unit") {
-            if (this->parent->MeasuresPolarization())
-                throw ConeUnitException("The 'Unit' emission model does not support polarization measurements.");
+        this->emission = new ConeSynchrotronEmission(this->parent->detector, this->parent->magfield, this->parent->MeasuresPolarization());
+    } else if (emname == "unit") {
+        if (this->parent->MeasuresPolarization())
+            throw ConeUnitException("The 'Unit' emission model does not support polarization measurements.");
 
-            this->emission = new ConeUnitEmission(this->parent->detector, this->parent->magfield);
-        } else
-            throw ConeException("Unrecognized emission model requested: '%s'.", emname.c_str());
+        this->emission = new ConeUnitEmission(this->parent->detector, this->parent->magfield);
+    } else
+        throw ConeException("Unrecognized emission model requested: '%s'.", emname.c_str());
 
-        this->emissionName = emname;
+    this->emissionName = emname;
     }
 
 /**

--- a/src/Tools/Radiation/Models/Cone/Configure.cpp
+++ b/src/Tools/Radiation/Models/Cone/Configure.cpp
@@ -75,7 +75,7 @@ void Cone::ConfigureEmission(const string& emname, ConfigBlock *conf) {
         if (conf->HasSetting("Z")) {
             Setting *s = conf->GetSetting("Z");
             if (!s->IsNumericVector())
-                throw ConeException("Invalid value assigned to paramter 'Z'. Expected real vector. If no Z-values are given, Z=1 by defualt.");
+                throw ConeException("Invalid value assigned to parameter 'Z'. Expected real vector. If no Z-values are given, Z=1 by defualt.");
             vector Z_vec = s->GetNumericVector();
             nspecies = Z_vec.size();
             delete []Z;
@@ -88,7 +88,7 @@ void Cone::ConfigureEmission(const string& emname, ConfigBlock *conf) {
         if (conf->HasSetting("n")) {
             Setting *s2 = conf->GetSetting("n");
             if (!s2->IsNumericVector())
-                throw ConeException("Invalid value assigned to paramter 'n'. Expected real vector. If no n-values are given, n=1 by default.");
+                throw ConeException("Invalid value assigned to parameter 'n'. Expected real vector. If no n-values are given, n=1 by default.");
             vector n_vec = s2->GetNumericVector();
             if(n_vec.size() != nspecies)
                 throw ConeException("Number of n-values do not match number of Z-values. If no n-values are given, n=1 by defualt.");
@@ -113,11 +113,11 @@ void Cone::ConfigureEmission(const string& emname, ConfigBlock *conf) {
             *s3 = conf->GetSetting("n");
 
         if(!s->IsNumericVector())
-            throw ConeException("Invalid value assigned to paramer Z, expected real vector");
+            throw ConeException("Invalid value assigned to parameter Z, expected real vector");
         if(!s2->IsNumericVector())
-            throw ConeException("Invalid value assigned to paramer Z0, expected real vector");
+            throw ConeException("Invalid value assigned to parameter Z0, expected real vector");
         if(!s3->IsNumericVector())
-            throw ConeException("Invalid value assigned to paramer n, expected real vector");
+            throw ConeException("Invalid value assigned to parameter n, expected real vector");
 
         vector Z_vec = s->GetNumericVector(),
             Z0_vec = s2->GetNumericVector(),
@@ -138,20 +138,27 @@ void Cone::ConfigureEmission(const string& emname, ConfigBlock *conf) {
             Z0[i] = Z0_vec[i];
             density[i] = n_vec[i];
         }
-        this->emission = new ConeBremsstrahlungScreenedEmission(this->parent->detector, this->parent->magfield, nspecies, Z, Z0, density);
+        slibreal_t qagsEpsRel = 1e-3;
+        if (conf->HasSetting("QAGS_EpsRel")){
+            Setting *s =conf->GetSetting("QAGS_EpsRel");
+            if (!s->IsScalar())
+                throw ConeException("Invalid value assigned to parameter QAGS_EpsRel, expected real scalar");
+            qagsEpsRel = s->GetScalar();
+        }
+        this->emission = new ConeBremsstrahlungScreenedEmission(this->parent->detector, this->parent->magfield, nspecies, Z, Z0, density, qagsEpsRel);
     }
-else if (emname == "synchrotron") {
-        this->emission = new ConeSynchrotronEmission(this->parent->detector, this->parent->magfield, this->parent->MeasuresPolarization());
-    } else if (emname == "unit") {
-        if (this->parent->MeasuresPolarization())
-            throw ConeUnitException("The 'Unit' emission model does not support polarization measurements.");
+    else if (emname == "synchrotron") {
+            this->emission = new ConeSynchrotronEmission(this->parent->detector, this->parent->magfield, this->parent->MeasuresPolarization());
+        } else if (emname == "unit") {
+            if (this->parent->MeasuresPolarization())
+                throw ConeUnitException("The 'Unit' emission model does not support polarization measurements.");
 
-        this->emission = new ConeUnitEmission(this->parent->detector, this->parent->magfield);
-    } else
-        throw ConeException("Unrecognized emission model requested: '%s'.", emname.c_str());
+            this->emission = new ConeUnitEmission(this->parent->detector, this->parent->magfield);
+        } else
+            throw ConeException("Unrecognized emission model requested: '%s'.", emname.c_str());
 
-    this->emissionName = emname;
-}
+        this->emissionName = emname;
+    }
 
 /**
  * Returns a string describing this model.

--- a/src/Tools/Radiation/Models/Cone/Emission/Bremsstrahlung/ConeBremsstrahlungScreenedEmission.cpp
+++ b/src/Tools/Radiation/Models/Cone/Emission/Bremsstrahlung/ConeBremsstrahlungScreenedEmission.cpp
@@ -7,7 +7,7 @@
 #include "Tools/Radiation/RadiationParticle.h"
 
 using namespace __Radiation;
-ConeBremsstrahlungScreenedEmission::ConeBremsstrahlungScreenedEmission(Detector *det, MagneticField2D *mf, unsigned int nspecies, slibreal_t *Z, slibreal_t *Z0, slibreal_t *density)
+ConeBremsstrahlungScreenedEmission::ConeBremsstrahlungScreenedEmission(Detector *det, MagneticField2D *mf, unsigned int nspecies, slibreal_t *Z, slibreal_t *Z0, slibreal_t *density, slibreal_t QAGSEpsRel)
                 : ConeEmission(det, mf), nspecies(nspecies)
 {
     this->Z = new slibreal_t[nspecies]; 
@@ -18,6 +18,7 @@ ConeBremsstrahlungScreenedEmission::ConeBremsstrahlungScreenedEmission(Detector 
         this->Z0[i] = Z0[i];
         this->density[i] =  density[i];
     }
+    this->qagsEpsRel = QAGSEpsRel;
     qagsWS = gsl_integration_workspace_alloc(qagsLimit); //GSL workspace
 }
 


### PR DESCRIPTION
Implemented setting the relative error tolerance for QAGS used for screened bremsstrahlung. Edited example pi-file accordingly. Cleaned in plotspectrum.py